### PR TITLE
Fix callback getting wrong key from database

### DIFF
--- a/05_opencart 3.x/catalog/controller/extension/payment/multibanco.php
+++ b/05_opencart 3.x/catalog/controller/extension/payment/multibanco.php
@@ -17,7 +17,7 @@ class ControllerExtensionPaymentMultibanco extends Controller {
 	}
 
 	public function callback(){
-		$chave_ap_int = $this->config->get('multibanco_ap');
+		$chave_ap_int = $this->config->get('payment_multibanco_ap');
 		$chave_ap_ext = $this->request->get['chave'];
 		$entidade = $this->request->get['entidade'];
 		$referencia = $this->request->get['referencia'];


### PR DESCRIPTION
$this->config->get('multibanco_ap'); appears to be for olders versions. The actual config key in DB is "payment_multibanco_ap"